### PR TITLE
Deploy only production code

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -192,6 +192,12 @@ class Tasks extends \Robo\Tasks
       ->checkout($branch)
       ->run();
 
+    // Discard any local changes made to the github repo during install.
+    $this->taskGitStack()
+      ->stopOnFail()
+      ->checkout($branch)
+      ->run();
+
     // Get the last commit from the remote branch.
     $last_remote_commit = $this->taskExec('git --no-pager log -1 --date=short --pretty=format:%ci')
       ->dir("$tmpDir/$hostDirName")
@@ -222,21 +228,20 @@ class Tasks extends \Robo\Tasks
       ->printed(FALSE)
       ->run();
 
+    // Rerun composer install for optimization and no dev items.
+    $this->taskComposerInstall()
+      ->dir("$tmpDir/deploy")
+      ->optimizeAutoloader()
+      ->noDev()
+      ->run();
+
     $this->taskGitStack()
       ->stopOnFail()
       ->dir("$tmpDir/deploy")
       ->add('-A')
       ->commit($commit_message)
       ->push('origin', $branch)
-//      ->tag('0.6.0')
-//      ->push('origin','0.6.0')
       ->run();
-
-    // Clean up
-//    $this->taskDeleteDir($tmpDir)
-//      ->run();
-
-
   }
 
   /**

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -192,16 +192,6 @@ class Tasks extends \Robo\Tasks
       ->checkout($branch)
       ->run();
 
-    // Discard any local changes made to the github repo during install.
-    // We only do this on Circle because if we do it on our local, it might
-    // discard our changes.
-    if(getenv('CIRCLECI')) {
-      $this->taskGitStack()
-        ->stopOnFail()
-        ->checkout($branch)
-        ->run();
-    }
-
     // Get the last commit from the remote branch.
     $last_remote_commit = $this->taskExec('git --no-pager log -1 --date=short --pretty=format:%ci')
       ->dir("$tmpDir/$hostDirName")

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -193,10 +193,14 @@ class Tasks extends \Robo\Tasks
       ->run();
 
     // Discard any local changes made to the github repo during install.
-    $this->taskGitStack()
-      ->stopOnFail()
-      ->checkout($branch)
-      ->run();
+    // We only do this on Circle because if we do it on our local, it might
+    // discard our changes.
+    if(getenv('CIRCLECI')) {
+      $this->taskGitStack()
+        ->stopOnFail()
+        ->checkout($branch)
+        ->run();
+    }
 
     // Get the last commit from the remote branch.
     $last_remote_commit = $this->taskExec('git --no-pager log -1 --date=short --pretty=format:%ci')


### PR DESCRIPTION
A couple of improvements:

1. Don't deploy our dev dependencies to Pantheon. Yuck!
2. Clean out any unstaged changes that might be  in the source directory. This is so far only specific to the settings.php file, which Drupal changes the permissions and "profile" value on during install. Since we're deploying a post-install site, this can cause havoc.

I put an if statement wrapper around that  second one  in case we still have sites deploying from their local machines. I know Shatterproof does. Do any older Pantheon D8 sites do that?