### PR TITLE
Fixes pantheon settings.php management

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "require": {
         "vlucas/phpdotenv": "^2.2",
-        "consolidation/robo": "^1.0.0-rc1"
+        "consolidation/robo": "^1.1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     },
     "require": {
         "vlucas/phpdotenv": "^2.2",
-        "consolidation/robo": "^1.1.0",
-        "se/selenium-server-standalone": "^3.9"
+        "consolidation/robo": "^1.1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,40 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "90f2880bd2361caff973aa35eb5cd954",
-    "content-hash": "db199b8a161cab71a78ebe655925aeda",
+    "content-hash": "84ce6d8e88c53b0f206c75ade0402ce0",
     "packages": [
         {
             "name": "consolidation/annotated-command",
-            "version": "1.2.1",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/annotated-command.git",
-                "reference": "296b4f507b1e184a28c9969bc7ae779f689db5ee"
+                "url": "https://github.com/consolidation/annotated-command.git",
+                "reference": "e97c38717eae23a2bafcf3f09438290eee6ebeb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/annotated-command/zipball/296b4f507b1e184a28c9969bc7ae779f689db5ee",
-                "reference": "296b4f507b1e184a28c9969bc7ae779f689db5ee",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/e97c38717eae23a2bafcf3f09438290eee6ebeb4",
+                "reference": "e97c38717eae23a2bafcf3f09438290eee6ebeb4",
                 "shasum": ""
             },
             "require": {
+                "consolidation/output-formatters": "^3.1.12",
                 "php": ">=5.4.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "psr/log": "~1.0",
-                "symfony/console": "~2.5|~3.0",
-                "symfony/finder": "~2.5|~3.0"
+                "psr/log": "^1",
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/event-dispatcher": "^2.5|^3|^4",
+                "symfony/finder": "^2.5|^3|^4"
             },
             "require-dev": {
-                "consolidation/output-formatters": "~1",
-                "phpunit/phpunit": "4.*",
-                "satooshi/php-coveralls": "^1.0",
-                "squizlabs/php_codesniffer": "2.*"
+                "phpunit/phpunit": "^4.8",
+                "satooshi/php-coveralls": "^1.0.2 | dev-master",
+                "squizlabs/php_codesniffer": "^2.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -56,29 +55,79 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2016-08-02 21:49:35"
+            "time": "2017-11-29T16:23:23+00:00"
         },
         {
-            "name": "consolidation/log",
-            "version": "1.0.3",
+            "name": "consolidation/config",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/log.git",
-                "reference": "74ba81b4edc585616747cc5c5309ce56fec41254"
+                "url": "https://github.com/consolidation/config.git",
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/log/zipball/74ba81b4edc585616747cc5c5309ce56fec41254",
-                "reference": "74ba81b4edc585616747cc5c5309ce56fec41254",
+                "url": "https://api.github.com/repos/consolidation/config/zipball/b59a3b9ea750c21397f26a68fd2e04d9580af42e",
+                "reference": "b59a3b9ea750c21397f26a68fd2e04d9580af42e",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^1.1.0",
+                "grasmash/yaml-expander": "^1.1",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4",
+                "satooshi/php-coveralls": "^1.0",
+                "squizlabs/php_codesniffer": "2.*",
+                "symfony/console": "^2.5|^3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Consolidation\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Anderson",
+                    "email": "greg.1.anderson@greenknowe.org"
+                }
+            ],
+            "description": "Provide configuration services for a commandline tool.",
+            "time": "2017-10-25T05:50:10+00:00"
+        },
+        {
+            "name": "consolidation/log",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/consolidation/log.git",
+                "reference": "dbc7c535f319a4a2d5a5077738f8eb7c10df8821"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/dbc7c535f319a4a2d5a5077738f8eb7c10df8821",
+                "reference": "dbc7c535f319a4a2d5a5077738f8eb7c10df8821",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.0",
                 "psr/log": "~1.0",
-                "symfony/console": "~2.5|~3.0"
+                "symfony/console": "^2.8|^3|^4"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*",
+                "satooshi/php-coveralls": "dev-master",
                 "squizlabs/php_codesniffer": "2.*"
             },
             "type": "library",
@@ -103,35 +152,37 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2016-03-23 23:46:42"
+            "time": "2017-11-29T01:44:16+00:00"
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "1.0.0",
+            "version": "3.1.13",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/output-formatters.git",
-                "reference": "6428d8fb30c9ed3b96314580808b3e4415b46dd9"
+                "url": "https://github.com/consolidation/output-formatters.git",
+                "reference": "3188461e965b32148c8fb85261833b2b72d34b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/output-formatters/zipball/6428d8fb30c9ed3b96314580808b3e4415b46dd9",
-                "reference": "6428d8fb30c9ed3b96314580808b3e4415b46dd9",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/3188461e965b32148c8fb85261833b2b72d34b8c",
+                "reference": "3188461e965b32148c8fb85261833b2b72d34b8c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "symfony/console": "~2.5|~3.0"
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/finder": "^2.5|^3|^4"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*",
-                "satooshi/php-coveralls": "^1.0",
-                "squizlabs/php_codesniffer": "2.*"
+                "phpunit/phpunit": "^4.8",
+                "satooshi/php-coveralls": "^1.0.2 | dev-master",
+                "squizlabs/php_codesniffer": "^2.7",
+                "victorjonsson/markdowndocs": "^1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -150,52 +201,54 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2016-05-20 04:17:55"
+            "time": "2017-11-29T15:25:38+00:00"
         },
         {
             "name": "consolidation/robo",
-            "version": "1.0.0-RC1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation-org/Robo.git",
-                "reference": "f82b67307ecc6e96eeb022b1415d5ae9f024b061"
+                "url": "https://github.com/consolidation/Robo.git",
+                "reference": "c46c13de3eca55e6b3635f363688ce85e845adf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation-org/Robo/zipball/f82b67307ecc6e96eeb022b1415d5ae9f024b061",
-                "reference": "f82b67307ecc6e96eeb022b1415d5ae9f024b061",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/c46c13de3eca55e6b3635f363688ce85e845adf0",
+                "reference": "c46c13de3eca55e6b3635f363688ce85e845adf0",
                 "shasum": ""
             },
             "require": {
-                "consolidation/annotated-command": "^1.2",
+                "consolidation/annotated-command": "^2.8.2",
+                "consolidation/config": "^1.0.1",
                 "consolidation/log": "~1",
-                "consolidation/output-formatters": "~1",
+                "consolidation/output-formatters": "^3.1.13",
+                "grasmash/yaml-expander": "^1.3",
                 "league/container": "^2.2",
                 "php": ">=5.5.0",
-                "symfony/console": "~2.5|~3.0",
-                "symfony/event-dispatcher": "~2.5|~3.0",
-                "symfony/filesystem": "~2.5|~3.0",
-                "symfony/finder": "~2.5|~3.0",
-                "symfony/process": "~2.5|~3.0"
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/event-dispatcher": "^2.5|^3|^4",
+                "symfony/filesystem": "^2.5|^3|^4",
+                "symfony/finder": "^2.5|^3|^4",
+                "symfony/process": "^2.5|^3|^4"
             },
             "replace": {
                 "codegyre/robo": "< 1.0"
             },
             "require-dev": {
-                "codeception/aspect-mock": "0.5.4",
-                "codeception/base": "^2.1.5",
-                "codeception/verify": "0.2.*",
-                "henrikbjorn/lurker": "~1",
-                "natxet/cssmin": "~3",
-                "patchwork/jsqueeze": "~1",
-                "pear/archive_tar": "~1",
-                "phpunit/php-code-coverage": "~2",
-                "satooshi/php-coveralls": "^1",
-                "squizlabs/php_codesniffer": "~2"
+                "codeception/aspect-mock": "^1|^2.1.1",
+                "codeception/base": "^2.3.7",
+                "codeception/verify": "^0.3.2",
+                "greg-1-anderson/composer-test-scenarios": "^1",
+                "natxet/cssmin": "3.0.4",
+                "patchwork/jsqueeze": "~2",
+                "pear/archive_tar": "^1.4.2",
+                "phpunit/php-code-coverage": "~2|~4",
+                "satooshi/php-coveralls": "^2",
+                "squizlabs/php_codesniffer": "^2.8"
             },
             "suggest": {
                 "henrikbjorn/lurker": "For monitoring filesystem changes in taskWatch",
-                "natxet/CssMin": "For minifying JS files in taskMinify",
+                "natxet/CssMin": "For minifying CSS files in taskMinify",
                 "patchwork/jsqueeze": "For minifying JS files in taskMinify",
                 "pear/archive_tar": "Allows tar archives to be created and extracted in taskPack and taskExtract, respectively."
             },
@@ -205,7 +258,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "1.x-dev",
+                    "dev-state": "1.x-dev"
                 }
             },
             "autoload": {
@@ -224,21 +278,24 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2016-08-04 22:12:32"
+            "time": "2017-12-13T02:10:49+00:00"
         },
         {
             "name": "container-interop/container-interop",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
                 "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -251,28 +308,137 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
-            "name": "league/container",
-            "version": "2.2.0",
+            "name": "dflydev/dot-access-data",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/thephpleague/container.git",
-                "reference": "c0e7d947b690891f700dc4967ead7bdb3d6708c1"
+                "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/c0e7d947b690891f700dc4967ead7bdb3d6708c1",
-                "reference": "c0e7d947b690891f700dc4967ead7bdb3d6708c1",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
-                "php": ">=5.4.0"
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Dflydev\\DotAccessData": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dragonfly Development Inc.",
+                    "email": "info@dflydev.com",
+                    "homepage": "http://dflydev.com"
+                },
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com",
+                    "homepage": "http://beausimensen.com"
+                },
+                {
+                    "name": "Carlos Frutos",
+                    "email": "carlos@kiwing.it",
+                    "homepage": "https://github.com/cfrutos"
+                }
+            ],
+            "description": "Given a deep data structure, access data by dot notation.",
+            "homepage": "https://github.com/dflydev/dflydev-dot-access-data",
+            "keywords": [
+                "access",
+                "data",
+                "dot",
+                "notation"
+            ],
+            "time": "2017-01-20T21:14:22+00:00"
+        },
+        {
+            "name": "grasmash/yaml-expander",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/grasmash/yaml-expander.git",
+                "reference": "3f45a3e1ff1d7ace6544c49f526127318abbb75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/grasmash/yaml-expander/zipball/3f45a3e1ff1d7ace6544c49f526127318abbb75c",
+                "reference": "3f45a3e1ff1d7ace6544c49f526127318abbb75c",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^1.1.0",
+                "php": ">=5.4",
+                "symfony/yaml": "^2.8.11|^3|^4"
+            },
+            "require-dev": {
+                "greg-1-anderson/composer-test-scenarios": "^1",
+                "phpunit/phpunit": "^4.8|^5.5.4",
+                "satooshi/php-coveralls": "^1.0.2|dev-master",
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Grasmash\\YamlExpander\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Grasmick"
+                }
+            ],
+            "description": "Expands internal property references in a yaml file.",
+            "time": "2017-12-08T17:42:26+00:00"
+        },
+        {
+            "name": "league/container",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/43f35abd03a12977a60ffd7095efd6a7808488c0",
+                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "php": "^5.4.0 || ^7.0"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.1"
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
             },
             "replace": {
                 "orno/di": "~2.0"
@@ -283,7 +449,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev",
+                    "dev-2.x": "2.x-dev",
                     "dev-1.x": "1.x-dev"
                 }
             },
@@ -315,172 +481,83 @@
                 "provider",
                 "service"
             ],
-            "time": "2016-03-17 11:07:59"
+            "time": "2017-05-10T09:20:27+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2015-12-27 11:43:31"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2016-06-10 07:14:17"
-        },
-        {
-            "name": "psr/log",
+            "name": "psr/container",
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -494,45 +571,54 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.3",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5"
+                "reference": "2ff6acc1342a0e7c3ad757a80fd837f5b22535a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f9e638e8149e9e41b570ff092f8007c477ef0ce5",
-                "reference": "f9e638e8149e9e41b570ff092f8007c477ef0ce5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2ff6acc1342a0e7c3ad757a80fd837f5b22535a1",
+                "reference": "2ff6acc1342a0e7c3ad757a80fd837f5b22535a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
+                "php": "^7.1.3",
                 "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
+                "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -559,31 +645,34 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-26 08:04:17"
+            "time": "2017-12-04T12:31:58+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.3",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5"
+                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
-                "reference": "c0c00c80b3a69132c4e55c3e7db32b4a387615e5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/6223fb2b68e7059e8d5843c0103999a84e7275cf",
+                "reference": "6223fb2b68e7059e8d5843c0103999a84e7275cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0",
-                "symfony/dependency-injection": "~2.8|~3.0",
-                "symfony/expression-language": "~2.8|~3.0",
-                "symfony/stopwatch": "~2.8|~3.0"
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/expression-language": "~3.4|~4.0",
+                "symfony/stopwatch": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -592,7 +681,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -619,29 +708,29 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:45:57"
+            "time": "2017-11-09T17:30:28+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.1.3",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "bb29adceb552d202b6416ede373529338136e84f"
+                "reference": "c9d4a26759ff75a077e4e334315cb632739b661a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/bb29adceb552d202b6416ede373529338136e84f",
-                "reference": "bb29adceb552d202b6416ede373529338136e84f",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c9d4a26759ff75a077e4e334315cb632739b661a",
+                "reference": "c9d4a26759ff75a077e4e334315cb632739b661a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -668,29 +757,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-20 05:44:26"
+            "time": "2017-11-21T14:14:53+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.3",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7"
+                "reference": "c9cdda4dc4a3182d8d6daeebce4a25fef078ea4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8201978de88a9fa0923e18601bb17f1df9c721e7",
-                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/c9cdda4dc4a3182d8d6daeebce4a25fef078ea4c",
+                "reference": "c9cdda4dc4a3182d8d6daeebce4a25fef078ea4c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -717,20 +806,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2017-11-07T14:45:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -742,7 +831,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -776,29 +865,29 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.1.3",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "04c2dfaae4ec56a5c677b0c69fac34637d815758"
+                "reference": "685dc11afcaaea72d7fd11c26835d12b091338f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/04c2dfaae4ec56a5c677b0c69fac34637d815758",
-                "reference": "04c2dfaae4ec56a5c677b0c69fac34637d815758",
+                "url": "https://api.github.com/repos/symfony/process/zipball/685dc11afcaaea72d7fd11c26835d12b091338f4",
+                "reference": "685dc11afcaaea72d7fd11c26835d12b091338f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^7.1.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -825,20 +914,78 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 11:13:48"
+            "time": "2017-11-22T12:29:35+00:00"
         },
         {
-            "name": "vlucas/phpdotenv",
-            "version": "v2.3.0",
+            "name": "symfony/yaml",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "9ca5644c536654e9509b9d257f53c58630eb2a6a"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "873417cb9949f07be8852d41e3be5ab6f09e1218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/9ca5644c536654e9509b9d257f53c58630eb2a6a",
-                "reference": "9ca5644c536654e9509b9d257f53c58630eb2a6a",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/873417cb9949f07be8852d41e3be5ab6f09e1218",
+                "reference": "873417cb9949f07be8852d41e3be5ab6f09e1218",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-12-04T18:34:52+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
+                "reference": "3cc116adbe4b11be5ec557bf1d24dc5e3a21d18c",
                 "shasum": ""
             },
             "require": {
@@ -850,7 +997,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -875,65 +1022,13 @@
                 "env",
                 "environment"
             ],
-            "time": "2016-06-14 14:14:52"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-09-01T10:05:43+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "consolidation/robo": 5
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5375116820e19bfbd41de44a5d6e774c",
+    "content-hash": "84ce6d8e88c53b0f206c75ade0402ce0",
     "packages": [
         {
             "name": "consolidation/annotated-command",
@@ -578,49 +578,6 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
-        },
-        {
-            "name": "se/selenium-server-standalone",
-            "version": "3.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sveneisenschmidt/selenium-server-standalone.git",
-                "reference": "246cbe221c963b4491c6beab14c3eb055b369ce1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sveneisenschmidt/selenium-server-standalone/zipball/246cbe221c963b4491c6beab14c3eb055b369ce1",
-                "reference": "246cbe221c963b4491c6beab14c3eb055b369ce1",
-                "shasum": ""
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "bin/selenium-server-standalone"
-            ],
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Sven Eisenschmidt",
-                    "email": "sven.eisenschmidt@gmail.com"
-                },
-                {
-                    "name": "James Titcumb",
-                    "email": "hello@jamestitcumb.com"
-                }
-            ],
-            "description": "Composer distribution of Selenium Server Standalone, the browser automation framework. Adds a executable to your composer bin directory.",
-            "homepage": "https://github.com/sveneisenschmidt/selenium-server-standalone",
-            "keywords": [
-                "selenium",
-                "testing"
-            ],
-            "time": "2018-02-14T15:10:10+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -376,7 +376,7 @@ class Tasks extends \Robo\Tasks
     // Trigger remote install.
     if ($opts['install']) {
       $this->_exec("terminus env:wipe $terminus_site_env --yes");
-      return $this->install(array('pantheon' => TRUE));
+      return $this->pantheonInstall();
     }
   }
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -391,7 +391,7 @@ class Tasks extends \Robo\Tasks
     $sftp_command = trim($this->_exec('terminus site connection-info --field=sftp_command')->getMessage());
     $sftp_command = str_replace('sftp', 'sftp -b -', $sftp_command);
     $sftp_command .= ' << EOF
-chmod 644 code/sites/default/settings.php
+chmod 644 code/web/sites/default/settings.php
 EOF';
     $this->_exec($sftp_command);
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -356,6 +356,10 @@ class Tasks extends \Robo\Tasks
           return FALSE;
         }
       }
+      if (strlen($terminus_env) > 11) {
+        $this->say('Couldn\'t create multidev: Pantheon environment names are restricted to 11 characters.');
+        return FALSE;
+      }
       $this->taskExec("terminus multidev:create $terminus_site.dev $terminus_env")
         ->run();
     }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -403,7 +403,7 @@ EOF';
     return $this->test(['profile' => 'pantheon', 'feature' => $opts['feature']]);
   }
 
-  private function getProjectProperties() {
+  protected function getProjectProperties() {
 
     $properties = ['project' => '', 'hash_salt' => '', 'config_dir' => '', 'host_repo' => ''];
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -413,7 +413,6 @@ EOF';
     // Run the installation.
     $result = $this->taskExec($install_cmd)
       ->run();
-
     // Put the site back into git mode.
     $this->_exec("terminus connection:set $terminus_site_env git");
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -7,12 +7,6 @@ use Symfony\Component\Process\Process;
 
 class Tasks extends \Robo\Tasks
 {
-
-  // The version of this project used in setUpBehat(). Will be downloaded from
-  // https://docs.seleniumhq.org/download/. Must be compatible with
-  // chromedriver.
-  const SELENIUM_SERVER_STANDALONE_VERSION = '3.10.0';
-
   private $projectProperties;
 
   function __construct() {
@@ -373,31 +367,6 @@ class Tasks extends \Robo\Tasks
           ->run();
       }
     }
-
-    // Be sure we've got the copy of Selenium Server Standalone we need.
-    $sss_ver = self::SELENIUM_SERVER_STANDALONE_VERSION; // Copied because it's a pain to type. Also read.
-    $sss_file = "selenium-server-standalone-{$sss_ver}.jar";
-    $got_sss = $this
-      ->taskExec("ls behat/selenium/{$sss_file}")
-      ->run()
-      ->wasSuccessful();
-    if (!$got_sss) {
-      $subdir = substr($sss_ver, 0, strrpos($sss_ver, '.'));
-      $this
-        ->taskExec("wget http://selenium-release.storage.googleapis.com/{$subdir}/$sss_file")
-        ->run();
-      $this->taskFilesystemStack()
-        ->mkdir('behat/selenium')
-        ->run();
-      $this->taskFilesystemStack()
-        ->rename($sss_file, "behat/selenium/$sss_file")
-        ->run();
-    }
-
-    // Now run SSS, which relies on chromedriver.
-    $this->taskExec("java -jar behat/selenium/$sss_file -port 4444")
-      ->background()
-      ->run();
   }
 
   /**

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -302,12 +302,12 @@ class Tasks extends \Robo\Tasks
    */
   function test($opts = ['feature' => NULL, 'profile' => 'local']) {
     $behat_cmd = $this->taskExec('behat')
-      ->arg('--config behat/behat.' . $opts['profile'] . '.yml')
-      ->arg(' --profile ' . $opts['profile'])
-      ->arg(' --format progress');
+      ->option('config', 'behat/behat.' . $opts['profile'] . '.yml')
+      ->option('profile', $opts['profile'])
+      ->option('format', 'progress');
 
     if ($opts['feature']) {
-      $behat_cmd->arg($opts['feature']);
+      $behat_cmd->rawArg($opts['feature']);
     }
 
     $behat_result = $behat_cmd->run();

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -247,8 +247,21 @@ class Tasks extends \Robo\Tasks
    * @return \Robo\Result
    */
   function install() {
-
-    $install_cmd = 'site-install ' . $this->projectProperties['install_profile'] . ' -y';
+    // Use user environment settings if we have them.
+    if ($system_defaults = getenv('PRESSFLOW_SETTINGS')) {
+      $settings = json_decode($system_defaults, TRUE);
+      $db_settings = $settings['databases']['default']['default'];
+      $install_cmd = 'site-install ' . $this->projectProperties['install_profile'] .
+        ' --db-url=mysql://' . $db_settings['username'] .
+        ':' . $db_settings['password'] .
+        '@' . $db_settings['host'] .
+        ':' . $db_settings['port'] .
+        '/' . $db_settings['database'] .
+        ' -y';
+    }
+    else {
+      $install_cmd = 'site-install standard -y';
+    }
 
     // Install dependencies. Only works locally.
     $this->taskComposerInstall()

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -64,6 +64,7 @@ class Tasks extends \Robo\Tasks
    * @option string db-name Database name.
    * @option string db-host Database host.
    * @option string branch Branch.
+   * @option string profile install profile.
    */
   function configure($opts = [
     'db-pass' => NULL,
@@ -71,6 +72,7 @@ class Tasks extends \Robo\Tasks
     'db-name' => NULL,
     'db-host' => NULL,
     'branch' => NULL,
+    'profile' => 'standard',
   ]) {
 
     $settings = $this->getDefaultPressflowSettings();
@@ -147,9 +149,15 @@ class Tasks extends \Robo\Tasks
       ->run();
 
     // If branch was specified, write it out to the .env file for future runs.
-    $result = $this->taskWriteToFile('.env')
+    $this->taskWriteToFile('.env')
       ->append()
       ->line('TS_BRANCH=' . $branch)
+      ->run();
+
+    // If profile was specified, write it out to the .env file for future runs.
+    $result = $this->taskWriteToFile('.env')
+      ->append()
+      ->line('TS_INSTALL_PROFILE=' . $this->projectProperties['profile'])
       ->run();
 
     return $result;

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -392,7 +392,7 @@ class Tasks extends \Robo\Tasks
 
     // Even in SFTP mode, the settings.php file might have too restrictive
     // permissions. We use SFTP to chmod the settings file before installing.
-    $sftp_command = trim($this->_exec("terminus connection:info --field=sftp_command $terminus_site_env")->getMessage());
+    $sftp_command = trim(exec("terminus connection:info --field=sftp_command $terminus_site_env"));
     $sftp_command = str_replace('sftp', 'sftp -b -', $sftp_command);
     // Use webroot to find settings.php assume  webroot is the gitroot if no
     // webroot is specified.
@@ -404,10 +404,11 @@ class Tasks extends \Robo\Tasks
     }
     $default_dir = 'code/' . $web_root . 'sites/default';
     $sftp_command .= ' << EOF
-chmod 644 ' . $default_dir . '
-chmod 644 ' . $default_dir . '/settings.php
-EOF';
-    $this->_exec($sftp_command);
+chmod 755 ' . $default_dir . '
+chmod 755 ' . $default_dir . '/settings.php';
+    // Note that we don't use $this->_exec on purpose. SFTP command fails
+    // with that operation: a fix would be great but this actually works.
+    exec($sftp_command);
 
     // Run the installation.
     $result = $this->taskExec($install_cmd)

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -403,8 +403,10 @@ class Tasks extends \Robo\Tasks
     else {
       $web_root = '';
     }
+    $default_dir = 'code/' . $web_root . 'sites/default';
     $sftp_command .= ' << EOF
-chmod 644 code/' . $web_root . 'sites/default/settings.php
+chmod 644 ' . $default_dir . '
+chmod 644 ' . $default_dir . '/settings.php
 EOF';
     $this->_exec($sftp_command);
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -62,12 +62,14 @@ class Tasks extends \Robo\Tasks
   /**
    * Generate configuration in your .env file.
    *
-   * @option string db-pass Database password.
-   * @option string db-user Database user.
-   * @option string db-name Database name.
-   * @option string db-host Database host.
-   * @option string branch Branch.
-   * @option string profile install profile.
+   * @option array $opts Contains the following key options:
+   *   db-pass:    Database password.
+   *   db-user:    Database user.
+   *   db-name:    Database name.
+   *   db-host:    Database host.
+   *   branch:     Git Branch.
+   *   profile:    install profile.
+   *   db-upgrade: local migration database name.
    */
   function configure($opts = [
     'db-pass' => NULL,
@@ -76,6 +78,7 @@ class Tasks extends \Robo\Tasks
     'db-host' => NULL,
     'branch' => NULL,
     'profile' => 'standard',
+    'db-upgrade' => NULL,
   ]) {
 
     $settings = $this->getDefaultPressflowSettings();
@@ -113,6 +116,12 @@ class Tasks extends \Robo\Tasks
     // Override DB host from project properties.
     if (isset($this->projectProperties['db-host'])) {
       $settings['databases']['default']['default']['host'] = $this->projectProperties['db-host'];
+    }
+
+    // Set Upgrade database.
+    if (isset($this->projectProperties['db-upgrade']) && $this->projectProperties['db-upgrade'] != $this->projectProperties['db-name']) {
+      $settings['databases']['upgrade'] = $settings['databases']['default'];
+      $settings['databases']['upgrade']['default']['database'] = $this->projectProperties['db-upgrade'];
     }
 
     // Hash Salt.

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -57,8 +57,6 @@ class Tasks extends \Robo\Tasks
   /**
    * Generate configuration in your .env file.
    *
-   * @arg array opts function options:
-   *
    * @option string db-pass Database password.
    * @option string db-user Database user.
    * @option string db-name Database name.

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -195,12 +195,12 @@ class Tasks extends \Robo\Tasks
       ->run();
 
     // Get the last commit from the remote branch.
-    $last_remote_commit = $this->taskExec('git log -1 --date=short --pretty=format:%ci')
+    $last_remote_commit = $this->taskExec('git --no-pager log -1 --date=short --pretty=format:%ci')
       ->dir("$tmpDir/$hostDirName")
       ->run();
     $last_commit_date = trim($last_remote_commit->getMessage());
 
-    $commit_message = $this->taskExec("git log --pretty=format:'%h %s' --no-merges --since='$last_commit_date'")->run()->getMessage();
+    $commit_message = $this->taskExec("git --no-pager log --pretty=format:'%h %s' --no-merges --since='$last_commit_date'")->run()->getMessage();
 
     $commit_message = "Combined commits: \n" . $commit_message;
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -184,8 +184,8 @@ class Tasks extends \Robo\Tasks
       ->run();
     $last_commit_date = trim($last_remote_commit->getMessage());
 
-    $commit_message = $this->_exec("git log --pretty=format:'%h %s' --no-merges --since='$last_commit_date'")->getMessage();
-
+    $commit_message = $this->taskExec("git log --pretty=format:'%h %s' --no-merges --since='$last_commit_date'")->run()->getMessage();
+    
     $commit_message = "Combined commits: \n" . $commit_message;
 
     // Copy webroot to our deploy directory.

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -32,12 +32,12 @@ class Tasks extends \Robo\Tasks
       array(
         'source' => 'composer.json',
         'from' => '"name": "thinkshout/drupal-project",',
-        'to' => '"name": "thinkshout/' . $git_repo .'",',
+        'to' => '"name": "thinkshout/' . $git_repo . '",',
       ),
       array(
         'source' => '.env.dist',
         'from' => 'TS_PROJECT="SITE"',
-        'to' => 'TS_PROJECT="' . $git_repo .'"',
+        'to' => 'TS_PROJECT="' . $git_repo . '"',
       ),
       array(
         'source' => 'README.md',
@@ -57,13 +57,21 @@ class Tasks extends \Robo\Tasks
   /**
    * Generate configuration in your .env file.
    *
+   * @arg array opts function options:
+   *
    * @option string db-pass Database password.
    * @option string db-user Database user.
    * @option string db-name Database name.
    * @option string db-host Database host.
    * @option string branch Branch.
    */
-  function configure($opts = ['db-pass' => NULL, 'db-user' => NULL, 'db-name' => NULL, 'db-host' => NULL, 'branch' => NULL]) {
+  function configure($opts = [
+    'db-pass' => NULL,
+    'db-user' => NULL,
+    'db-name' => NULL,
+    'db-host' => NULL,
+    'branch' => NULL,
+  ]) {
 
     $settings = $this->getDefaultPressflowSettings();
 
@@ -131,7 +139,7 @@ class Tasks extends \Robo\Tasks
     $this->_remove('.env');
     $this->_copy('.env.dist', '.env');
 
-    $result = $this->taskWriteToFile('.env')
+    $this->taskWriteToFile('.env')
       ->append()
       ->line('# Generated configuration')
       ->line('PRESSFLOW_SETTINGS=' . $json_settings)

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -393,8 +393,16 @@ class Tasks extends \Robo\Tasks
     // permissions. We use SFTP to chmod the settings file before installing.
     $sftp_command = trim($this->_exec("terminus connection:info --field=sftp_command $terminus_site_env")->getMessage());
     $sftp_command = str_replace('sftp', 'sftp -b -', $sftp_command);
+    // Use webroot to find settings.php assume  webroot is the gitroot if no
+    // webroot is specified.
+    if (getenv('TS_WEB_ROOT')) {
+      $web_root = getenv('TS_WEB_ROOT') . '/';
+    }
+    else {
+      $web_root = '';
+    }
     $sftp_command .= ' << EOF
-chmod 644 code/web/sites/default/settings.php
+chmod 644 code/' . $web_root . 'sites/default/settings.php
 EOF';
     $this->_exec($sftp_command);
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -185,7 +185,7 @@ class Tasks extends \Robo\Tasks
     $last_commit_date = trim($last_remote_commit->getMessage());
 
     $commit_message = $this->taskExec("git log --pretty=format:'%h %s' --no-merges --since='$last_commit_date'")->run()->getMessage();
-    
+
     $commit_message = "Combined commits: \n" . $commit_message;
 
     // Copy webroot to our deploy directory.
@@ -232,7 +232,7 @@ class Tasks extends \Robo\Tasks
    */
   function install() {
 
-    $install_cmd = 'site-install config_installer -y';
+    $install_cmd = 'site-install ' . $this->projectProperties['install_profile'] . ' -y';
 
     // Install dependencies. Only works locally.
     $this->taskComposerInstall()
@@ -351,7 +351,7 @@ class Tasks extends \Robo\Tasks
    * @return \Robo\Result
    */
   function pantheonInstall() {
-    $install_cmd = 'site-install config_installer -y';
+      $install_cmd = 'site-install ' . $this->projectProperties['install_profile'] . ' -y';
 
     $install_cmd = 'terminus drush "' . $install_cmd . '"';
     // Pantheon wants the site in SFTP for installs.
@@ -405,7 +405,7 @@ EOF';
 
   protected function getProjectProperties() {
 
-    $properties = ['project' => '', 'hash_salt' => '', 'config_dir' => '', 'host_repo' => ''];
+    $properties = ['project' => '', 'hash_salt' => '', 'config_dir' => '', 'host_repo' => '', 'install_profile' => 'standard'];
 
     $properties['working_dir'] = getcwd();
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -157,7 +157,7 @@ class Tasks extends \Robo\Tasks
     // If profile was specified, write it out to the .env file for future runs.
     $result = $this->taskWriteToFile('.env')
       ->append()
-      ->line('TS_INSTALL_PROFILE=' . $this->projectProperties['profile'])
+      ->line('TS_INSTALL_PROFILE=' . $this->projectProperties['install_profile'])
       ->run();
 
     return $result;

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -403,6 +403,8 @@ class Tasks extends \Robo\Tasks
       $web_root = '';
     }
     $default_dir = 'code/' . $web_root . 'sites/default';
+    // We use 755 instead of 644 so settings.php is executable, and the
+    // directory is stat-able (otherwise we can't chmod the php file)
     $sftp_command .= ' << EOF
 chmod 755 ' . $default_dir . '
 chmod 755 ' . $default_dir . '/settings.php';


### PR DESCRIPTION
2 things happening here. First, we use a different command, (see #6), to get the proper sftp syntax.

Second, we use 755 instead of 644 for our permissions settings: that's necessary for the directory, otherwise you can't actually view the contents and the second command gets an error. It's necessary for settings.php because php files should be executable.

Third, we use a non-robo command to execute the sftp call, because no matter what I did the robo version produced errors. There's probably a way to make it work, but I ran out of patience.