### PR TITLE
Config helpers

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -901,7 +901,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     }
     else {
       $this->say('No migration source folder configured.');
-      $this->say('To use this command, you must implement the migrationSourceFolder() method in your project RoboFile.php.');
+      $this->say('To use this command, you must return a folder path string within the migrationSourceFolder() method in your project RoboFile.php.');
       return FALSE;
     }
   }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -862,7 +862,7 @@ chmod 755 ' . $default_dir . '/settings.php';
    * @return bool
    *   If the remote database was reached and downloaded, return TRUE.
    */
-  protected function getDatabaseOfTruth() {
+  private function getDatabaseOfTruth() {
     $current_command = $this->input()->getArgument('command');
     $project_properties = $this->getProjectProperties();
     if (!$this->databaseSourceOfTruth()) {

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -861,7 +861,7 @@ chmod 755 ' . $default_dir . '/settings.php';
   protected function getDatabaseOfTruth() {
     $current_command = $this->input()->getArgument('command');
     $project_properties = $this->getProjectProperties();
-    if ($this->databaseSourceOfTruth()) {
+    if (!$this->databaseSourceOfTruth()) {
       $this->say('No source database configured.');
       $this->say('To use this command, you must implement the databaseSourceOfTruth() method in your project RoboFile.php.');
       return FALSE;

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -867,7 +867,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     $project_properties = $this->getProjectProperties();
     if (!$this->databaseSourceOfTruth()) {
       $this->say('No source database configured.');
-      $this->say('To use this command, you must a string from the databaseSourceOfTruth() method in your project RoboFile.php.');
+      $this->say('To use this command, you must return a string from the databaseSourceOfTruth() method in your project RoboFile.php.');
       return FALSE;
     }
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -840,6 +840,7 @@ chmod 755 ' . $default_dir . '/settings.php';
    *   If the remote database was reached and downloaded, return TRUE.
    */
   protected function getDatabaseOfTruth() {
+    $current_command = $this->input()->getArgument('command');
     $project_properties = $this->getProjectProperties();
     if (!isset($project_properties['database_of_truth'])) {
       $this->say('No source database configured. To use this command, you must add a TS_DATABASE_OF_TRUTH value to your .env file. Example: TS_DATABASE_OF_TRUTH=live');
@@ -854,7 +855,7 @@ chmod 755 ' . $default_dir . '/settings.php';
       return TRUE;
     }
     else {
-      $this->yell('Remote database sync failed. Please run robo install again.');
+      $this->yell('Remote database sync failed. Please run `robo ' . $current_command . '`` again.');
       return FALSE;
     }
   }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -863,7 +863,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     $project_properties = $this->getProjectProperties();
     if (!$this->databaseSourceOfTruth()) {
       $this->say('No source database configured.');
-      $this->say('To use this command, you must implement the databaseSourceOfTruth() method in your project RoboFile.php.');
+      $this->say('To use this command, you must a string from the databaseSourceOfTruth() method in your project RoboFile.php.');
       return FALSE;
     }
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -20,7 +20,7 @@ class Tasks extends \Robo\Tasks
    *   Return the Pantheon environment you want to pull in on install (live,
    *   dev, etc), or FALSE to install from scratch.
    */
-  private function databaseSourceOfTruth() {
+  protected function databaseSourceOfTruth() {
     return 'live';
   }
 
@@ -32,7 +32,7 @@ class Tasks extends \Robo\Tasks
    *   (example: 'modules/custom/my_migration/config/install'), or FALSE if you
    *   are running no ongoing migrations.
    */
-  private function migrationSourceFolder() {
+  protected function migrationSourceFolder() {
     return FALSE;
   }
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -5,7 +5,7 @@ namespace ThinkShout\RoboDrupal;
 use Drupal\Component\Utility\Crypt;
 use Symfony\Component\Process\Process;
 
-abstract class Tasks extends \Robo\Tasks
+class Tasks extends \Robo\Tasks
 {
   private $projectProperties;
 
@@ -20,7 +20,9 @@ abstract class Tasks extends \Robo\Tasks
    *   Return the Pantheon environment you want to pull in on install (live,
    *   dev, etc), or FALSE to install from scratch.
    */
-  abstract protected function databaseSourceOfTruth();
+  private function databaseSourceOfTruth() {
+    return 'live';
+  }
 
   /**
    * Determines the migration folder to pull config from.
@@ -30,7 +32,9 @@ abstract class Tasks extends \Robo\Tasks
    *   (example: 'modules/custom/my_migration/config/install'), or FALSE if you
    *   are running no ongoing migrations.
    */
-  abstract protected function migrationSourceFolder();
+  private function migrationSourceFolder() {
+    return FALSE;
+  }
 
   /**
    * Initialize the project for the first time.

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -520,7 +520,7 @@ chmod 755 ' . $default_dir . '/settings.php';
 
   protected function getProjectProperties() {
 
-    $properties = ['project' => '', 'hash_salt' => '', 'config_dir' => '', 'host_repo' => '', 'install_profile' => 'standard', 'admin_name' => 'admin', 'database_of_truth' => 'database_of_truth'];
+    $properties = ['project' => '', 'hash_salt' => '', 'config_dir' => '', 'host_repo' => '', 'install_profile' => 'standard', 'admin_name' => 'admin', 'database_of_truth' => NULL];
 
     $properties['working_dir'] = getcwd();
 
@@ -855,7 +855,7 @@ chmod 755 ' . $default_dir . '/settings.php';
       return TRUE;
     }
     else {
-      $this->yell('Remote database sync failed. Please run `robo ' . $current_command . '`` again.');
+      $this->yell('Remote database sync failed. Please run `robo ' . $current_command . '` again.');
       return FALSE;
     }
   }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -276,10 +276,9 @@ class Tasks extends \Robo\Tasks
    * @return \Robo\Result
    */
   function install() {
-    $project_properties = $this->getProjectProperties();
     if(getenv('CIRCLECI')) {
       // Do nothing custom here.
-      $this->trueFreshInstall();
+      return $this->trueFreshInstall();
     }
     elseif ($this->databaseSourceOfTruth()) {
       $this->prepareLocal();


### PR DESCRIPTION
Takes a bunch of helper functions I've scattered across our projects and centralizes them into the robo-drupal repo. Functions include:

- `post:deploy`: Run after deploying to pantheon's dev or develop sites so we don't have to manually reimport config there.
- `pull:config`: A helper function that pulls a live database down to your local, then exports its active configy.
- `prepareLocal`: A helper function that runs as part of `robo install` if you've set a database of truth (so, a stable database, like the live site on Pantheon.)
- `post:install`: A function to be run after installing a clean database. It can do things like run migrations and add some dummy users, but only if you pull it into your RoboFile.php -- basically this function doesn't make sense to do anything at the robo-drupal level, but I wanted a place to drop sample code.
- `migrate:cleanup`: A function intended to help while creating and altering migrations. The guts are the same regardless of the project, but the migration configuration folder will vary. That value is pulled into its own function, migrationSourceFolder(), that is intended to be overwritten per project while migrations are ongoing. Once migrations are done, the extending method can be removed.