### PR TITLE
Issue 17 sql sync terminus wget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -790,7 +790,7 @@ chmod 755 ' . $default_dir . '/settings.php';
   public function prepareLocal() {
     $do_composer_install = TRUE;
     $project_properties = $this->getProjectProperties();
-    $grab_database = $this->confirm("Grab a fresh database?");
+    $grab_database = $this->confirm("Load a database backup?");
     if ($grab_database == 'y') {
       $do_composer_install = $this->getDatabaseOfTruth();
     }
@@ -876,6 +876,12 @@ chmod 755 ' . $default_dir . '/settings.php';
 
     $this->say('Emptying existing database.');
     $empty_database = $this->taskExec('drush sql-drop -y @self')->dir($project_properties['web_root'])->run();
+
+    $this->say('This command populates your database from a backup .sql.gz file.');
+    $this->say('If you already have a database backup in your  vendor folder, the "local" option will be available.');
+    $this->say('If you want to grab a more recent backup from Pantheon, type in the environemnt name (dev, test, live)');
+    $this->say('Backups are generated on Pantheon regularly, but might be old.');
+    $this->say('If you need the very latest data from a Pantheon site, go create a new backup using either the Pantheon backend, or Terminus.');
 
     $which_database = $this->askDefault(
       'Which database backup should we load (local/dev/live)?', $default_database

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -890,12 +890,9 @@ chmod 755 ' . $default_dir . '/settings.php';
       $default_database = 'local';
     }
 
-    $this->say('Emptying existing database.');
-    $empty_database = $this->taskExec('drush sql-drop -y @self')->dir($project_properties['web_root'])->run();
-
-    $this->say('This command populates your database from a backup .sql.gz file.');
+    $this->say('This command will drop all tables in your local database and re-populate from a backup .sql.gz file.');
     $this->say('If you already have a database backup in your  vendor folder, the "local" option will be available.');
-    $this->say(' If you want to grab a more recent backup from Pantheon, type in the environment name (dev, test, live). This will be saved to your vendor folder for future re-installs.');
+    $this->say('If you want to grab a more recent backup from Pantheon, type in the environment name (dev, test, live). This will be saved to your vendor folder for future re-installs.');
     $this->say('Backups are generated on Pantheon regularly, but might be old.');
     $this->say('If you need the very latest data from a Pantheon site, go create a new backup using either the Pantheon backend, or Terminus.');
 
@@ -903,8 +900,17 @@ chmod 755 ' . $default_dir . '/settings.php';
       'Which database backup should we load (local/dev/live)?', $default_database
     );
 
+    $getDB = TRUE;
     if ($which_database !== 'local') {
       $getDB = $this->downloadPantheonBackup($which_database);
+    }
+
+    if ($getDB) {
+      $this->say('Emptying existing database.');
+      $empty_database = $this->taskExec('drush sql-drop -y @self')->dir($project_properties['web_root'])->run();
+    }
+    else {
+      $this->yell('Database backup failed. Your old database is still installed');
     }
 
     return $this->importLocal();

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -908,12 +908,12 @@ chmod 755 ' . $default_dir . '/settings.php';
     if ($getDB) {
       $this->say('Emptying existing database.');
       $empty_database = $this->taskExec('drush sql-drop -y @self')->dir($project_properties['web_root'])->run();
+      return $this->importLocal();
     }
     else {
-      $this->yell('Database backup failed. Your old database is still installed');
+      $this->yell('Failed to download a Pantheon backup. Database was not refreshed.');
+      return false;
     }
-
-    return $this->importLocal();
   }
 
   /**

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -879,7 +879,7 @@ chmod 755 ' . $default_dir . '/settings.php';
 
     $drush_commands    = [
       'drush_drop_database'   => 'drush sql-drop -y @self',
-      'drush_import_database' => 'terminus remote:drush ' . $terminus_site_env . ' -- sql-dump | drush @self sqlc',
+      'drush_import_database' => 'drush @pantheon.' . $terminus_site_env . ' sql-dump | drush @self sqlc',
     ];
     $database_download = $this->taskExec(implode(' && ', $drush_commands))->dir($project_properties['web_root'])->run();
     if ($database_download->wasSuccessful()) {

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -879,7 +879,7 @@ chmod 755 ' . $default_dir . '/settings.php';
 
     $drush_commands    = [
       'drush_drop_database'   => 'drush sql-drop -y @self',
-      'drush_import_database' => 'drush sql-sync @pantheon.' . $terminus_site_env . ' @self -y',
+      'drush_import_database' => 'terminus remote:drush ' . $terminus_site_env . ' -- sql-dump | drush @self sqlc',
     ];
     $database_download = $this->taskExec(implode(' && ', $drush_commands))->dir($project_properties['web_root'])->run();
     if ($database_download->wasSuccessful()) {

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -905,7 +905,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     }
 
     $drush_commands    = [
-      'drush_import_database' => 'zcat < vendor/database.sql.gz | drush @self sqlc # Importing local copy of db.'
+      'drush_import_database' => 'zcat < vendor/database.sql.gz | drush sqlc @self # Importing local copy of db.'
     ];
     $database_import = $this->taskExec(implode(' && ', $drush_commands))->run();
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -759,18 +759,21 @@ chmod 755 ' . $default_dir . '/settings.php';
   public function pullConfig() {
     $project_properties = $this->getProjectProperties();
     $terminus_site_env  = $this->getPantheonSiteEnv($this->databaseSourceOfTruth());
-    $terminus_url_request = $this->taskExec('terminus backup:create ' . $terminus_site_env . ' --element="db"')
-      ->dir($project_properties['web_root'])
-      ->interactive(false)
-      ->run();
 
-    if ($terminus_url_request->wasSuccessful()) {
-      $do_composer_install = $this->downloadPantheonBackup($this->databaseSourceOfTruth());
+    $grab_database = $this->confirm("To pull the latest config, you should create a new backup on Pantheon. Create backup now?");
+    if ($grab_database == 'y') {
+      $terminus_url_request = $this->taskExec('terminus backup:create ' . $terminus_site_env . ' --element="db"')
+        ->dir($project_properties['web_root'])
+        ->interactive(false)
+        ->run();
     }
-    else {
+
+    if (!$terminus_url_request->wasSuccessful()) {
       $this->yell('Could not make a Database backup of "'. $terminus_site_env . '"! See if you can make one manually.');
       return FALSE;
     }
+
+    $do_composer_install = $this->downloadPantheonBackup($this->databaseSourceOfTruth());
 
     if ($do_composer_install) {
       $this->taskComposerInstall()

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -911,7 +911,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     }
 
     $drush_commands    = [
-      'drush_import_database' => 'zcat < vendor/database.sql.gz | drush @self sqlc # Importing local copy of db.'
+      'drush_import_database' => 'zcat < vendor/database.sql.gz | drush sqlc @self # Importing local copy of db.'
     ];
     $database_import = $this->taskExec(implode(' && ', $drush_commands))->run();
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -953,10 +953,12 @@ chmod 755 ' . $default_dir . '/settings.php';
    *   True if import succeeded.
    */
   public function importLocal() {
+    $project_properties = $this->getProjectProperties();
+
     $drush_commands    = [
       'drush_import_database' => 'zcat < vendor/database.sql.gz | drush sqlc @self # Importing local copy of db.'
     ];
-    $database_import = $this->taskExec(implode(' && ', $drush_commands))->run();
+    $database_import = $this->taskExec(implode(' && ', $drush_commands))->dir($project_properties['web_root'])->run();
 
     if ($database_import->wasSuccessful()) {
       return TRUE;

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -879,7 +879,7 @@ chmod 755 ' . $default_dir . '/settings.php';
 
     $this->say('This command populates your database from a backup .sql.gz file.');
     $this->say('If you already have a database backup in your  vendor folder, the "local" option will be available.');
-    $this->say('If you want to grab a more recent backup from Pantheon, type in the environemnt name (dev, test, live)');
+    $this->say(' If you want to grab a more recent backup from Pantheon, type in the environment name (dev, test, live). This will be saved to your vendor folder for future re-installs.');
     $this->say('Backups are generated on Pantheon regularly, but might be old.');
     $this->say('If you need the very latest data from a Pantheon site, go create a new backup using either the Pantheon backend, or Terminus.');
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -899,10 +899,16 @@ chmod 755 ' . $default_dir . '/settings.php';
         'drush_import_database' => 'zcat < vendor/database.sql.gz | drush @self sqlc'
       ];
       $database_import = $this->taskExec(implode(' && ', $drush_commands))->run();
-      return TRUE;
+
+      if ($database_import->wasSuccessful()) {
+        return TRUE;
+      }
+      else {
+        $this->yell('Could not read vendor/database.sql.gz into your local database. See if the command "zcat < vendor/database.sql.gz | drush @self sqlc" works outside of robo.');
+      }
     }
     else {
-      $this->yell('Remote database sync failed. Please run `robo ' . $current_command . '` again.');
+      $this->yell('Remote database sync failed.');
       return FALSE;
     }
   }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -956,7 +956,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     $project_properties = $this->getProjectProperties();
 
     $drush_commands    = [
-      'drush_import_database' => 'zcat < vendor/database.sql.gz | drush sqlc @self # Importing local copy of db.'
+      'drush_import_database' => 'zcat < ../vendor/database.sql.gz | drush sqlc @self # Importing local copy of db.'
     ];
     $database_import = $this->taskExec(implode(' && ', $drush_commands))->dir($project_properties['web_root'])->run();
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -758,7 +758,20 @@ chmod 755 ' . $default_dir . '/settings.php';
    */
   public function pullConfig() {
     $project_properties = $this->getProjectProperties();
-    $do_composer_install = $this->getDatabaseOfTruth();
+    $terminus_site_env  = $this->getPantheonSiteEnv($this->databaseSourceOfTruth());
+    $terminus_url_request = $this->taskExec('terminus backup:create ' . $terminus_site_env . ' --element="db"')
+      ->dir($project_properties['web_root'])
+      ->interactive(false)
+      ->run();
+
+    if ($terminus_url_request->wasSuccessful()) {
+      $do_composer_install = $this->getDatabaseOfTruth();
+    }
+    else {
+      $this->yell('Could not make a Database backup of "'. $terminus_site_env . '"! See if you can make one manually.');
+      return FALSE;
+    }
+
     if ($do_composer_install) {
       $this->taskComposerInstall()
         ->optimizeAutoloader()


### PR DESCRIPTION
To try this out for your site, use composer:

```
composer require thinkshout/robo-drupal dev-issue-17-sql-sync-terminus-wget --dev
```

This goes back to the older, `tbg` method of pulling down a copy of a site's database instead of using `drush` in any capacity on Pantheon. 

The new command outputs the following questions:

` Load a database backup? (y/n)` -- this question already existed in the install script, but it was phrased differently.

If you say 'y' you get some help text, and another question:

```
➜  This command populates your database from a backup .sql.gz file.
➜  If you already have a database backup in your  vendor folder, the "local" option will be available.
➜  If you want to grab a more recent backup from Pantheon, type in the environment name (dev, test, live). This will be saved to your vendor folder for future re-installs.
➜  Backups are generated on Pantheon regularly, but might be old.
➜  If you need the very latest data from a Pantheon site, go create a new backup using either the Pantheon backend, or Terminus.
?  Which database backup should we load (local/dev/live)? [live]
```

Note that the default value in that prompt is [live] -- that means I don't have a `database.sql.gz` file in my vendor folder right now. If I had one, I could use a local backup of the file, and avoid asking Pantheon for a backup at all.

What this helps fix:

- Allows people to explicitly choose which database backup they're getting
- Avoids doing a sql-sync  to get the database
- Forces devs to download a backup instead of the latest live DB
- Allows devs who just want to reuse a local copy of the Pantheon database a place they can put their backup zip file to read it locally.

My question for the team:

- Does this work as expected?
- Does the help text make it clear what this is doing?
- Any red flags/concerns?
- Any suggested improvements?
