### PR TITLE
Fixing sql-drop syntax in getDatabaseOfTruth

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -924,7 +924,7 @@ chmod 755 ' . $default_dir . '/settings.php';
 
     if ($getDB) {
       $this->say('Emptying existing database.');
-      $empty_database = $this->taskExec('drush sql-drop -y @self')->dir($project_properties['web_root'])->run();
+      $empty_database = $this->taskExec('drush sql:drop -y')->dir($project_properties['web_root'])->run();
       return $this->importLocal();
     }
     else {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6163565/55174695-4e0ba700-5154-11e9-9730-21da421d45f0.png)

After:
![image](https://user-images.githubusercontent.com/6163565/55174755-654a9480-5154-11e9-82a7-de2274b55b23.png)
