### PR TITLE
Remove CleanDir task during deploy

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -236,10 +236,6 @@ class Tasks extends \Robo\Tasks
       ->mkdir("$tmpDir/$hostDirName")
       ->run();
 
-    // Make sure we have an empty temp dir.
-    $this->taskCleanDir([$tmpDir])
-      ->run();
-
     // Git checkout of the matching remote branch.
     $this->taskGitStack()
       ->stopOnFail()

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -244,6 +244,7 @@ class Tasks extends \Robo\Tasks
       ->cloneRepo($repo, "$tmpDir/$hostDirName")
       ->run();
 
+    // Git checkout of the matching remote branch.
     $this->taskGitStack()->dir("$tmpDir/$hostDirName")
       ->checkout($pantheon_branch)
       ->run();

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -233,14 +233,18 @@ class Tasks extends \Robo\Tasks
     $this->stopOnFail();
     $fs = $this->taskFilesystemStack()
       ->mkdir($tmpDir)
-      ->mkdir("$tmpDir/$hostDirName")
       ->run();
 
-    // Git checkout of the matching remote branch.
+    // Make sure we have an empty temp dir.
+    $this->taskCleanDir([$tmpDir])
+      ->run();
+
     $this->taskGitStack()
       ->stopOnFail()
       ->cloneRepo($repo, "$tmpDir/$hostDirName")
-      ->dir("$tmpDir/$hostDirName")
+      ->run();
+
+    $this->taskGitStack()->dir("$tmpDir/$hostDirName")
       ->checkout($pantheon_branch)
       ->run();
 


### PR DESCRIPTION
* Having an error during CORI deploy:
```
 [Filesystem\FilesystemStack] mkdir ["/tmp/drupal-deploy-1622655096"]
 [Filesystem\FilesystemStack] mkdir ["/tmp/drupal-deploy-1622655096/host"]
 [Filesystem\CleanDir] Cleaned /tmp/drupal-deploy-1622655096
 [Vcs\GitStack] Running git commands...
 [Vcs\GitStack] Executing git clone ssh://codeserver.dev.fcf2c912-81cc-42a1-8bc9-fe80f04cb455@codeserver.dev.fcf2c912-81cc-42a1-8bc9-fe80f04cb455.drush.in:2222/~/repository.git /tmp/drupal-deploy-1622655096/host
 [Vcs\GitStack] Running git clone ssh://codeserver.dev.fcf2c912-81cc-42a1-8bc9-fe80f04cb455@codeserver.dev.fcf2c912-81cc-42a1-8bc9-fe80f04cb455.drush.in:2222/~/repository.git /tmp/drupal-deploy-1622655096/host in /tmp/drupal-deploy-1622655096/host
 [error]  The provided cwd "/tmp/drupal-deploy-1622655096/host" does not exist. 
```

Testing to see if this fixes it and/or why we cleanDir to begin with 