### PR TITLE
Faster db import with progress bar

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -635,7 +635,13 @@ chmod 755 ' . $default_dir . '/settings.php';
       $properties['branch'] = trim($branch);
     }
 
-    if ($db_name = getenv('TS_DB_NAME')) {
+    if ($system_defaults = getenv('PRESSFLOW_SETTINGS')) {
+      $db_settings = json_decode($system_defaults, TRUE)['databases']['default']['default'];
+      $properties['db-name'] = $db_settings['database'];
+      $properties['db-user'] = $db_settings['username'];
+      $properties['db-pass'] = $db_settings['password'];
+    }
+    elseif ($db_name = getenv('TS_DB_NAME')) {
       $properties['db-name'] = $db_name;
     }
     else {

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -965,11 +965,11 @@ chmod 755 ' . $default_dir . '/settings.php';
    * @return bool
    *   If the remote database was reached and downloaded, return TRUE.
    */
-  private function getDatabaseOfTruth() {
+  protected function getDatabaseOfTruth() {
     $project_properties = $this->getProjectProperties();
     $default_database = $this->databaseSourceOfTruth();
 
-    if (file_exists('vendor/database.sql.gz')) {
+    if (file_exists('vendor/database.sql.gz') || file_exists('vendor/database.sql')) {
       $default_database = 'local';
     }
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -1048,6 +1048,11 @@ chmod 755 ' . $default_dir . '/settings.php';
    *   True if import succeeded.
    */
   public function importLocal() {
+    if (!$this->taskExec('which pv')->run()->wasSuccessful()) {
+      $this->yell("This project's database can take up to an hour to import. So that you can be informed of its progress, please install the pv tool with 'brew install pv', then run your command again.");
+      return FALSE;
+    }
+
     $project_properties = $this->getProjectProperties();
 
     $web_root = $project_properties['web_root'];
@@ -1060,7 +1065,7 @@ chmod 755 ' . $default_dir . '/settings.php';
       $this->taskExec('gunzip ../vendor/database.sql.gz')->dir($web_root)->run();
     }
     $import_commands    = [
-      'drush_import_database' => "mysql -u$sql_user -p$sql_pass $sql_db < ../vendor/database.sql # Importing local copy of db."
+      'drush_import_database' => "pv ../vendor/database.sql | mysql -u$sql_user -p$sql_pass $sql_db # Importing local copy of db."
     ];
     $database_import = $this->taskExec(implode(' && ', $import_commands))->dir($web_root)->run();
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -975,7 +975,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     $project_properties = $this->getProjectProperties();
     $default_database = $this->databaseSourceOfTruth();
 
-    if (file_exists('vendor/database.sql.gz') || file_exists('vendor/database.sql')) {
+    if (file_exists('vendor/database.sql.gz')) {
       $default_database = 'local';
     }
 
@@ -1056,16 +1056,12 @@ chmod 755 ' . $default_dir . '/settings.php';
     $project_properties = $this->getProjectProperties();
 
     $web_root = $project_properties['web_root'];
-    $sql_db = $project_properties['db-name'];
-    $sql_user = $project_properties['db-user'];
-    $sql_pass = $project_properties['db-pass'];
+
     // Empty out the old database so deleted tables don't stick around.
     $this->taskExec('drush sql:drop -y')->dir($web_root)->run();
-    if (file_exists('vendor/database.sql.gz')) {
-      $this->taskExec('gunzip ../vendor/database.sql.gz')->dir($web_root)->run();
-    }
+
     $import_commands    = [
-      'drush_import_database' => "pv ../vendor/database.sql | mysql -u$sql_user -p$sql_pass $sql_db # Importing local copy of db."
+      'drush_import_database' => "pv ../vendor/database.sql.gz | zcat | $(drush sql:connect) # Importing local copy of db."
     ];
     $database_import = $this->taskExec(implode(' && ', $import_commands))->dir($web_root)->run();
 
@@ -1073,7 +1069,7 @@ chmod 755 ' . $default_dir . '/settings.php';
       return TRUE;
     }
     else {
-      $this->yell("Could not read vendor/database.sql into your local database. See if the command 'mysql -u$sql_user -p$sql_pass $sql_db < vendor/database.sql' works outside of robo.");
+      $this->yell("Could not read vendor/database.sql.gz into your local database. See if the command 'pv vendor/database.sql.gz | zcat | $(drush sql:connect)' works outside of robo.");
       return FALSE;
     }
   }


### PR DESCRIPTION
This changes our import of databases to use mysql instead of zcat, which operates more than twice as fast on the huge LVHN database.

It also resolves #68 by looping in the Pipe Viewer utility.