### PR TITLE
Change dotenv usage to be compatible with latest version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     },
     "require": {
-        "vlucas/phpdotenv": ">2.2",
+        "vlucas/phpdotenv": ">=5.0",
         "consolidation/robo": "^1.3",
         "drush/drush": "^9.6|^10.0"
     }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -2,6 +2,7 @@
 
 namespace ThinkShout\RoboDrupal;
 
+use Dotenv\Dotenv;
 use Drupal\Component\Utility\Crypt;
 use Symfony\Component\Process\Process;
 
@@ -603,7 +604,8 @@ chmod 755 ' . $default_dir . '/settings.php';
     // Load .env file from the local directory if it exists. Or use the .env.dist
     $env_file = (file_exists($properties['working_dir'] . '/.env')) ? '.env' : '.env.dist';
 
-    $dotenv = new \Dotenv\Dotenv($properties['working_dir'], $env_file);
+
+    $dotenv = Dotenv::createUnsafeImmutable($properties['working_dir'], $env_file);
     $dotenv->load();
 
     array_walk($properties, function(&$var, $key) {

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -606,7 +606,7 @@ chmod 755 ' . $default_dir . '/settings.php';
 
 
     $dotenv = Dotenv::createUnsafeImmutable($properties['working_dir'], $env_file);
-    $dotenv->load();
+    $dotenv->safeLoad();
 
     array_walk($properties, function(&$var, $key) {
       $env_var = strtoupper('TS_' . $key);


### PR DESCRIPTION
Got myself into a pickle with that last PR! Turns out newer versions of dotenv DO behave differently. Also requires a new version of the load.environment.php that looks like this, not sure how to include that here:
```php
<?php

/**
 * This file is included very early. See autoload.files in composer.json and
 * https://getcomposer.org/doc/04-schema.md#files
 */

use Dotenv\Dotenv;

/**
 * Load any .env file. See /.env.example.
 *
 * Drupal has no official method for loading environment variables and uses
 * getenv() in some places.
 */
$dotenv = Dotenv::createUnsafeImmutable(__DIR__);
$dotenv->safeLoad();
```