### PR TITLE
Behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "vlucas/phpdotenv": ">=5.0",
         "consolidation/robo": "^3.0",
         "drupal/config_split": "^2.0",
-        "drush/drush": "^9.6|^10.0|^11.1"
+        "drush/drush": "^9.6|^10.0|^11.1",
+        "genesis/behat-fail-aid": "^3.7"
     }
 }

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -399,7 +399,8 @@ class Tasks extends \Robo\Tasks
     $behat_cmd = $this->taskExec('behat')
       ->option('config', 'behat/behat.' . $opts['profile'] . '.yml')
       ->option('profile', $opts['profile'])
-      ->option('format', 'progress');
+      ->option('format', 'progress')
+      ->option('stop-on-failure');
 
     if ($opts['feature']) {
       $behat_cmd->rawArg($opts['feature']);
@@ -412,14 +413,6 @@ class Tasks extends \Robo\Tasks
     $behat_result = $behat_cmd->run();
 
     return $behat_result;
-
-    // @TODO consider adding unit tests back in. These are slow and aren't working great right now.
-//    $unit_result = $this->taskPHPUnit('../vendor/bin/phpunit')
-//      ->dir('core')
-//      ->run();
-//
-//    // @TODO will need to address multiple results when we enable other tests as well.
-//    return $behat_result->merge($unit_result);
   }
 
   /**

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -412,6 +412,11 @@ class Tasks extends \Robo\Tasks
 
     $behat_result = $behat_cmd->run();
 
+    if (!$behat_result->wasSuccessful()){
+      // Print out a debugging message.
+      $this->say('You just had a behat test fail! See https://library.thinkshoutlabs.com/articles/fixing-failing-behat-tests-locally-circleci for tips on how to fix this!');
+    }
+
     return $behat_result;
   }
 


### PR DESCRIPTION
Adding the fail test repo, which prints out a bit more information about your failing tests, and a link to what to do if tests fail. Also sets the option to stop on fail, so folks can see the output of their first failing test without having to wait for the whole suite to run.