### PR TITLE
Issue annotated command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "vlucas/phpdotenv": ">=5.0",
         "consolidation/robo": "^3.0",
-        "consolidation/annotated-command": "<=4.5.7",
+        "consolidation/annotated-command": "<=4.5.6",
         "drupal/config_split": "^2.0",
         "drush/drush": "^9.6|^10.0|^11.1",
         "genesis/behat-fail-aid": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "vlucas/phpdotenv": ">=5.0",
         "consolidation/robo": "^3.0",
+        "consolidation/annotated-command": "<=4.5.7",
         "drupal/config_split": "^2.0",
         "drush/drush": "^9.6|^10.0|^11.1",
         "genesis/behat-fail-aid": "^3.7"


### PR DESCRIPTION
the Annotated command release 4.5.7 has one change in it that breaks our ability to extend the ThinkShout Tasks file as part of our RoboFile. See the release https://github.com/consolidation/annotated-command/pull/273.

This branch locks robo-drupal down to the release before that.

I have a fix that will allow us to use the the 4.5.7 release, but it will require an update to the Robofile.php file for all our projects, to I'll make that a new major release.