### PR TITLE
4.x

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -6,7 +6,7 @@ use Dotenv\Dotenv;
 use Drupal\Component\Utility\Crypt;
 use Symfony\Component\Process\Process;
 
-trait Tasks extends \Robo\Tasks
+trait Tasks
 {
   private $projectProperties;
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -6,7 +6,7 @@ use Dotenv\Dotenv;
 use Drupal\Component\Utility\Crypt;
 use Symfony\Component\Process\Process;
 
-class Tasks extends \Robo\Tasks
+trait Tasks extends \Robo\Tasks
 {
   private $projectProperties;
 


### PR DESCRIPTION
Starting a v4 branch that will work with annotated commands 4.5.7 and greater.

This should be its own release tag, because it requires making a change to your Robofile.php file, although it's a quite easy change. (See example)
https://github.com/thinkshout/ccal/pull/594/files#diff-fed7dd361d1a8d696657705806d8e756ff49cc4659f2191ab0e91172a59be0d8

Basically, replace:
`class RoboFile extends \ThinkShout\RoboDrupal\Tasks {`
with:
```
class RoboFile extends \Robo\Tasks {
  use \ThinkShout\RoboDrupal\Tasks;
```

[That pr](https://github.com/thinkshout/ccal/pull/594/files) also contains a good example of how to call the parent trait from within the overridden function.

Define the original trait's function within a scope (here the function is called "test"):
```
   use \ThinkShout\RoboDrupal\Tasks {
    test as protected traittest;
  }
```

Replace `parent::test()` (or whatever the function is) with:
```
$this->traittest($opts);
```

This should not be merged until https://github.com/thinkshout/robo-drupal/issues/78 is.