### PR TITLE
Fixes required to not throw warnings when using php 8.1

### DIFF
--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -282,7 +282,7 @@ class Tasks extends \Robo\Tasks
       ->exclude('.gitignore')
       ->exclude('sites/default/settings.local.php')
       ->exclude('sites/default/files')
-      ->printed(FALSE)
+      ->printOutput(FALSE)
       ->run();
 
     // Move host .git into our deployment directory.
@@ -290,7 +290,7 @@ class Tasks extends \Robo\Tasks
       ->fromPath("$tmpDir/$hostDirName/.git")
       ->toPath("$tmpDir/deploy")
       ->args('-a', '-v', '-z', '--no-group', '--no-owner')
-      ->printed(FALSE)
+      ->printOutput(FALSE)
       ->run();
 
     // Rerun composer install for optimization and no dev items.

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -638,7 +638,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     if (!isset($properties['branch'])) {
       // Get the current branch using the simple exec command.
       $command = 'git symbolic-ref --short -q HEAD';
-      $process = new Process($command);
+      $process = new Process([$command]);
       $process->setTimeout(NULL);
       $process->setWorkingDirectory($properties['working_dir']);
       $process->run();

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -638,7 +638,7 @@ chmod 755 ' . $default_dir . '/settings.php';
     if (!isset($properties['branch'])) {
       // Get the current branch using the simple exec command.
       $command = 'git symbolic-ref --short -q HEAD';
-      $process = new Process([$command]);
+      $process = Process::fromShellCommandline($command);
       $process->setTimeout(NULL);
       $process->setWorkingDirectory($properties['working_dir']);
       $process->run();


### PR DESCRIPTION
## Merging/Testing requirements:
If `robo install` and `robo configure` and `robo pull:config` all work without warnings, plus sites are deploying without warnings, this one can be approved.