### PR TITLE
Drush12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "vlucas/phpdotenv": ">=5.0",
         "consolidation/robo": "^3.0 || ^4.0",
-        "consolidation/annotated-command": "<=4.5.6",
+        "consolidation/annotated-command": "^4.8.2",
         "drupal/config_split": "^2.0",
         "drush/drush": "^9.6|^10.0|^11.1|^12.0",
         "genesis/behat-fail-aid": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "vlucas/phpdotenv": ">=5.0",
         "consolidation/robo": "^3.0 || ^4.0",
-        "consolidation/annotated-command": "^4.8.2",
+        "consolidation/annotated-command": "^4.8",
         "drupal/config_split": "^2.0",
         "drush/drush": "^9.6|^10.0|^11.1|^12.0",
         "genesis/behat-fail-aid": "^3.7"

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,9 @@
     },
     "require": {
         "vlucas/phpdotenv": ">=5.0",
-        "consolidation/robo": "^3.0 || ^4.0",
-        "consolidation/annotated-command": "^4.8",
         "drupal/config_split": "^2.0",
-        "drush/drush": "^9.6|^10.0|^11.1|^12.0"
+        "drush/drush": ">=9.6",
+        "genesis/behat-fail-aid": "^3.6"
     },
     "extra": {
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "consolidation/robo": "^3.0 || ^4.0",
         "consolidation/annotated-command": "<=4.5.6",
         "drupal/config_split": "^2.0",
-        "drush/drush": "^9.6|^10.0|^11.1",
+        "drush/drush": "^9.6|^10.0|^11.1|^12.0",
         "genesis/behat-fail-aid": "^3.7"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "consolidation/robo": "^3.0 || ^4.0",
         "consolidation/annotated-command": "^4.8",
         "drupal/config_split": "^2.0",
-        "drush/drush": "^9.6|^10.0|^11.1|^12.0",
-        "genesis/behat-fail-aid": "^3.7"
+        "drush/drush": "^9.6|^10.0|^11.1|^12.0"
     },
     "extra": {
         "drupal-scaffold": {


### PR DESCRIPTION
Currently removes the behat fail aid. I'll review if we can get a set of dependencies that will work with that package, and if not, merge.

Update: Just had to downgrade the behat-fail-aid, then chose to rework the dependencies a bit. Drush already requires robo, and annotated, so just removing those.